### PR TITLE
bugfix/ledger-1.5.1-app

### DIFF
--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -358,6 +358,7 @@ class DeviceMgr(ThreadJob):
         self.clients = {}  # type: Dict[HardwareClientBase, Tuple[Union[str, bytes], str]]
         # What we recognise.  (vendor_id, product_id) -> Plugin
         self._recognised_hardware = {}  # type: Dict[Tuple[int, int], HW_PluginBase]
+        self._recognised_vendor = {}
         # Custom enumerate functions for devices we don't know about.
         self.enumerate_func = set()
         # For synchronization
@@ -381,6 +382,10 @@ class DeviceMgr(ThreadJob):
     def register_devices(self, device_pairs, *, plugin: 'HW_PluginBase'):
         for pair in device_pairs:
             self._recognised_hardware[pair] = plugin
+
+    def register_vendor_ids(self, vendor_ids: Iterable[int], *, plugin: 'HW_PluginBase'):
+        for vendor_id in vendor_ids:
+            self._recognised_vendor[vendor_id] = plugin
 
     def register_enumerate_func(self, func):
         self.enumerate_func.add(func)
@@ -521,7 +526,7 @@ class DeviceMgr(ThreadJob):
         devices = [dev for dev in devices if not self.xpub_by_id(dev.id_)]
         infos = []
         for device in devices:
-            if device.product_key not in plugin.DEVICE_IDS:
+            if not plugin.can_recognize_device(device):
                 continue
             try:
                 client = self.create_client(device, handler, plugin)
@@ -595,11 +600,17 @@ class DeviceMgr(ThreadJob):
 
         devices = []
         for d in hid_list:
-            product_key = (d['vendor_id'], d['product_id'])
+            vendor_id = d['vendor_id']
+            product_key = (vendor_id, d['product_id'])
+            plugin = None
             if product_key in self._recognised_hardware:
                 plugin = self._recognised_hardware[product_key]
+            elif vendor_id in self._recognised_vendor:
+                plugin = self._recognised_vendor[vendor_id]
+            if plugin:
                 device = plugin.create_device_from_hid_enumeration(d, product_key=product_key)
-                devices.append(device)
+                if device:
+                    devices.append(device)
         return devices
 
     def scan_devices(self) -> List['Device']:

--- a/electrum/plugin.py
+++ b/electrum/plugin.py
@@ -356,9 +356,8 @@ class DeviceMgr(ThreadJob):
         # A list of clients.  The key is the client, the value is
         # a (path, id_) pair.
         self.clients = {}  # type: Dict[HardwareClientBase, Tuple[Union[str, bytes], str]]
-        # What we recognise.  Each entry is a (vendor_id, product_id)
-        # pair.
-        self.recognised_hardware = set()
+        # What we recognise.  (vendor_id, product_id) -> Plugin
+        self._recognised_hardware = {}  # type: Dict[Tuple[int, int], HW_PluginBase]
         # Custom enumerate functions for devices we don't know about.
         self.enumerate_func = set()
         # For synchronization
@@ -379,9 +378,9 @@ class DeviceMgr(ThreadJob):
         for client in clients:
             client.timeout(cutoff)
 
-    def register_devices(self, device_pairs):
+    def register_devices(self, device_pairs, *, plugin: 'HW_PluginBase'):
         for pair in device_pairs:
-            self.recognised_hardware.add(pair)
+            self._recognised_hardware[pair] = plugin
 
     def register_enumerate_func(self, func):
         self.enumerate_func.add(func)
@@ -597,20 +596,10 @@ class DeviceMgr(ThreadJob):
         devices = []
         for d in hid_list:
             product_key = (d['vendor_id'], d['product_id'])
-            if product_key in self.recognised_hardware:
-                # Older versions of hid don't provide interface_number
-                interface_number = d.get('interface_number', -1)
-                usage_page = d['usage_page']
-                id_ = d['serial_number']
-                if len(id_) == 0:
-                    id_ = str(d['path'])
-                id_ += str(interface_number) + str(usage_page)
-                devices.append(Device(path=d['path'],
-                                      interface_number=interface_number,
-                                      id_=id_,
-                                      product_key=product_key,
-                                      usage_page=usage_page,
-                                      transport_ui_string='hid'))
+            if product_key in self._recognised_hardware:
+                plugin = self._recognised_hardware[product_key]
+                device = plugin.create_device_from_hid_enumeration(d, product_key=product_key)
+                devices.append(device)
         return devices
 
     def scan_devices(self) -> List['Device']:
@@ -646,3 +635,4 @@ class DeviceMgr(ThreadJob):
             self.unpair_id(id_)
 
         return devices
+

--- a/electrum/plugins/hw_wallet/plugin.py
+++ b/electrum/plugins/hw_wallet/plugin.py
@@ -55,6 +55,22 @@ class HW_PluginBase(BasePlugin):
     def device_manager(self) -> 'DeviceMgr':
         return self.parent.device_manager
 
+    def create_device_from_hid_enumeration(self, d: dict, *, product_key) -> 'Device':
+        # Older versions of hid don't provide interface_number
+        interface_number = d.get('interface_number', -1)
+        usage_page = d['usage_page']
+        id_ = d['serial_number']
+        if len(id_) == 0:
+            id_ = str(d['path'])
+            id_ += str(interface_number) + str(usage_page)
+            device = Device(path=d['path'],
+                            interface_number = interface_number,
+                            id_ = id_,
+                            product_key = product_key,
+                            usage_page = usage_page,
+                            transport_ui_string = 'hid')
+        return device
+
     @hook
     def close_wallet(self, wallet: 'Abstract_Wallet'):
         for keystore in wallet.get_keystores():

--- a/electrum/plugins/hw_wallet/plugin.py
+++ b/electrum/plugins/hw_wallet/plugin.py
@@ -24,7 +24,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import TYPE_CHECKING, Dict, List, Union, Tuple, Sequence, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Union, Tuple, Sequence, Optional, Type, Iterable, Any
 
 from electrum.plugin import BasePlugin, hook, Device, DeviceMgr
 from electrum.i18n import _
@@ -43,6 +43,8 @@ class HW_PluginBase(BasePlugin):
 
     minimum_library = (0, )
 
+    DEVICE_IDS: Iterable[Any]
+
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
         self.device = self.keystore_class.device
@@ -55,20 +57,20 @@ class HW_PluginBase(BasePlugin):
     def device_manager(self) -> 'DeviceMgr':
         return self.parent.device_manager
 
-    def create_device_from_hid_enumeration(self, d: dict, *, product_key) -> 'Device':
+    def create_device_from_hid_enumeration(self, d: dict, *, product_key) -> Optional['Device']:
         # Older versions of hid don't provide interface_number
         interface_number = d.get('interface_number', -1)
         usage_page = d['usage_page']
         id_ = d['serial_number']
         if len(id_) == 0:
             id_ = str(d['path'])
-            id_ += str(interface_number) + str(usage_page)
-            device = Device(path=d['path'],
-                            interface_number = interface_number,
-                            id_ = id_,
-                            product_key = product_key,
-                            usage_page = usage_page,
-                            transport_ui_string = 'hid')
+        id_ += str(interface_number) + str(usage_page)
+        device = Device(path=d['path'],
+                        interface_number = interface_number,
+                        id_ = id_,
+                        product_key = product_key,
+                        usage_page = usage_page,
+                        transport_ui_string = 'hid')
         return device
 
     @hook
@@ -158,6 +160,12 @@ class HW_PluginBase(BasePlugin):
 
     def get_xpub(self, device_id, derivation: str, xtype, wizard) -> str:
         raise NotImplementedError()
+
+    def can_recognize_device(self, device: Device) -> bool:
+        """Whether the plugin thinks it can handle the given device.
+        Used for filtering all connected hardware devices to only those by this vendor.
+        """
+        return device.product_key in self.DEVICE_IDS
 
 
 class HardwareClientBase:

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -546,7 +546,7 @@ class LedgerPlugin(HW_PluginBase):
         self.segwit = config.get("segwit")
         HW_PluginBase.__init__(self, parent, config, name)
         if self.libraries_available:
-            self.device_manager().register_devices(self.DEVICE_IDS)
+            self.device_manager().register_devices(self.DEVICE_IDS, plugin=self)
 
     def get_btchip_device(self, device):
         ledger = False

--- a/electrum/plugins/ledger/ledger.py
+++ b/electrum/plugins/ledger/ledger.py
@@ -15,6 +15,8 @@ from electrum.wallet import Standard_Wallet
 from electrum.util import bfh, bh2u, versiontuple, UserFacingException
 from electrum.base_wizard import ScriptTypeNotSupported
 from electrum.logging import get_logger
+from electrum.plugin import Device
+from typing import Tuple, Optional
 
 from ..hw_wallet import HW_PluginBase, HardwareClientBase
 from ..hw_wallet.plugin import is_any_tx_output_on_change_branch
@@ -540,13 +542,21 @@ class LedgerPlugin(HW_PluginBase):
                    (0x2c97, 0x0009), # RFU
                    (0x2c97, 0x000a)  # RFU
                  ]
+    VENDOR_IDS = (0x2c97, )
+    LEDGER_MODEL_IDS = {
+        0x10: "Ledger Nano S",
+        0x40: "Ledger Nano X",
+    }
     SUPPORTED_XTYPES = ('standard', 'p2wpkh-p2sh', 'p2wpkh', 'p2wsh-p2sh', 'p2wsh')
 
     def __init__(self, parent, config, name):
         self.segwit = config.get("segwit")
         HW_PluginBase.__init__(self, parent, config, name)
         if self.libraries_available:
+            # to support legacy devices and legacy firmwares
             self.device_manager().register_devices(self.DEVICE_IDS, plugin=self)
+            # to support modern firmware
+            self.device_manager().register_vendor_ids(self.VENDOR_IDS, plugin=self)
 
     def get_btchip_device(self, device):
         ledger = False
@@ -617,3 +627,41 @@ class LedgerPlugin(HW_PluginBase):
         sequence = wallet.get_address_index(address)
         txin_type = wallet.get_txin_type(address)
         keystore.show_address(sequence, txin_type)
+
+    @classmethod
+    def _recognize_device(cls, product_key) -> Tuple[bool, Optional[str]]:
+        """Returns (can_recognize, model_name) tuple."""
+        # legacy product_keys
+        if product_key in cls.DEVICE_IDS:
+            if product_key[0] == 0x2581:
+                return True, "Ledger HW.1"
+            if product_key == (0x2c97, 0x0000):
+                return True, "Ledger Blue"
+            if product_key == (0x2c97, 0x0001):
+                return True, "Ledger Nano S"
+            if product_key == (0x2c97, 0x0004):
+                return True, "Ledger Nano X"
+            return True, None
+        # modern product_keys
+        if product_key[0] == 0x2c97:
+            product_id = product_key[1]
+            model_id = product_id >> 8
+            if model_id in cls.LEDGER_MODEL_IDS:
+                model_name = cls.LEDGER_MODEL_IDS[model_id]
+                return True, model_name
+        # give up
+        return False, None
+
+    def can_recognize_device(self, device: Device) -> bool:
+        return self._recognize_device(device.product_key)[0]
+
+    @classmethod
+    def device_name_from_product_key(cls, product_key) -> Optional[str]:
+        return cls._recognize_device(product_key)[1]
+
+    def create_device_from_hid_enumeration(self, d, *, product_key):
+        device = super().create_device_from_hid_enumeration(d, product_key=product_key)
+        if not self.can_recognize_device(device):
+            return None
+        return device
+


### PR DESCRIPTION
Update of btc ledger app to v 1.5.1 causes electrum (and in consequence electrum-vault) wallet to not recognize Ledger Nano device. This PR is porting fix that was delivered on electrum to solve this issue.