### PR TITLE
fix hint in ChooseLayout

### DIFF
--- a/electrum/gui/qt/util.py
+++ b/electrum/gui/qt/util.py
@@ -384,7 +384,7 @@ class ChoicesLayout(object):
         if hint is not None:
             hint_button = HintButton(text=hint, icon=None)
             hbox2.addWidget(hint_button)
-        hbox2.setAlignment(hint_button, Qt.AlignTop)
+            hbox2.setAlignment(hint_button, Qt.AlignTop)
 
         vbox.addLayout(hbox2)
 


### PR DESCRIPTION
Fix for

```
E | gui.qt.ElectrumGui | 
Traceback (most recent call last):
  File "/tmp/.mount_electrtFd4yY/usr/lib/python3.7/site-packages/electrum/gui/qt/__init__.py", line 368, in main
    self.init_network()
  File "/tmp/.mount_electrtFd4yY/usr/lib/python3.7/site-packages/electrum/gui/qt/__init__.py", line 343, in init_network
    wizard.init_network(self.daemon.network)
  File "/tmp/.mount_electrtFd4yY/usr/lib/python3.7/site-packages/electrum/gui/qt/installwizard.py", line 822, in init_network
    clayout = ChoicesLayout(message, choices)
  File "/tmp/.mount_electrtFd4yY/usr/lib/python3.7/site-packages/electrum/gui/qt/util.py", line 387, in __init__
    hbox2.setAlignment(hint_button, Qt.AlignTop)
UnboundLocalError: local variable 'hint_button' referenced before assignment
```